### PR TITLE
Redis Stream Commands and Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
-Cargo.lock
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,654 @@
+[[package]]
+name = "ascii"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mio"
+version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redis"
+version = "0.10.1-alpha.0"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redis_streams"
+version = "0.1.0"
+dependencies = [
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.10.1-alpha.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "smallvec"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tokio-codec"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-executor"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-reactor"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tcp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5fc969a8ce2c9c0c4b0429bb8431544f6658283c8326ba5ff8c762b75369335"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
+"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
+"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
+"checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
+"checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+"checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
+"checksum tokio-sync 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fda385df506bf7546e70872767f71e81640f1f251bdf2fd8eb81a0eaec5fe022"
+"checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "redis_streams"
+version = "0.1.0"
+authors = ["grippy <gmelton@gmail.com>"]
+edition = "2018"
+
+[dependencies.redis]
+path = "../redis-rs"
+
+[dev-dependencies]
+rand = "0.4"
+net2 = "0.2"
+futures = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 path = "../redis-rs"
 
 [dev-dependencies]
-rand = "0.4"
+rand = "0.6"
 net2 = "0.2"
 futures = "0.1"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test-all doc fmt
+
+fmt:
+	cargo +nightly fmt
+
+doc:
+	cargo doc --no-deps --jobs=10
+
+test-all:
+	RUST_BACKTRACE=true REDISRS_SERVER_TYPE=tcp cargo test -- --nocapture

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+format_strings = false
+use_try_shorthand = true

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,608 @@
+use crate::types::{
+    StreamClaimOptions, StreamClaimReply, StreamInfoConsumersReply, StreamInfoGroupsReply,
+    StreamInfoStreamReply, StreamMaxlen, StreamPendingCountReply, StreamPendingReply,
+    StreamRangeReply, StreamReadOptions, StreamReadReply,
+};
+
+use redis::{cmd, ConnectionLike, FromRedisValue, RedisResult, ToRedisArgs};
+
+
+/// Implementation of all redis stream commands.
+///
+pub trait StreamCommands: ConnectionLike + Sized {
+    // XACK <key> <group> <id> <id> ... <id>
+
+    /// Ack pending stream messages checked out by a consumer.
+    ///
+    #[inline]
+    fn xack<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        group: G,
+        ids: &[ID],
+    ) -> RedisResult<RV> {
+        cmd("XACK").arg(key).arg(group).arg(ids).query(self)
+    }
+
+    // XADD key <ID or *> [field value] [field value] ...
+
+    /// Add a stream message by `key`. Use `*` as the `id` for the current timestamp.
+    ///
+    #[inline]
+    fn xadd<K: ToRedisArgs, ID: ToRedisArgs, F: ToRedisArgs, V: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        id: ID,
+        items: &[(F, V)],
+    ) -> RedisResult<RV> {
+        cmd("XADD").arg(key).arg(id).arg(items).query(self)
+    }
+
+    // XADD key <ID or *> [rust BTreeMap] ...
+
+    /// BTreeMap variant for adding a stream message by `key`.
+    /// Use `*` as the `id` for the current timestamp.
+    ///
+    #[inline]
+    fn xadd_map<K: ToRedisArgs, ID: ToRedisArgs, BTM: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        id: ID,
+        map: BTM,
+    ) -> RedisResult<RV> {
+        cmd("XADD").arg(key).arg(id).arg(map).query(self)
+    }
+
+    // XADD key [MAXLEN [~|=] <count>] <ID or *> [field value] [field value] ...
+
+    /// Add a stream message while capping the stream at a maxlength.
+    ///
+    #[inline]
+    fn xadd_maxlen<
+        K: ToRedisArgs,
+        ID: ToRedisArgs,
+        F: ToRedisArgs,
+        V: ToRedisArgs,
+        RV: FromRedisValue,
+    >(
+        &mut self,
+        key: K,
+        maxlen: StreamMaxlen,
+        id: ID,
+        items: &[(F, V)],
+    ) -> RedisResult<RV> {
+        cmd("XADD")
+            .arg(key)
+            .arg(maxlen)
+            .arg(id)
+            .arg(items)
+            .query(self)
+    }
+
+    // XCLAIM <key> <group> <consumer> <min-idle-time> [<ID-1> <ID-2>]
+
+    /// Claim pending, unacked messages, after some period of time,
+    /// currently checked out by another consumer.
+    ///
+    /// This method only accepts the must-have arguments for claiming messages.
+    /// If optional arugments are required, see `xclaim_options` below.
+    ///
+    #[inline]
+    fn xclaim<K: ToRedisArgs, G: ToRedisArgs, C: ToRedisArgs, MIT: ToRedisArgs, ID: ToRedisArgs>(
+        &mut self,
+        key: K,
+        group: G,
+        consumer: C,
+        min_idle_time: MIT,
+        ids: &[ID],
+    ) -> RedisResult<StreamClaimReply> {
+        cmd("XCLAIM")
+            .arg(key)
+            .arg(group)
+            .arg(consumer)
+            .arg(min_idle_time)
+            .arg(ids)
+            .query(self)
+    }
+
+    // XCLAIM <key> <group> <consumer> <min-idle-time> <ID-1> <ID-2>
+    //     [IDLE <milliseconds>] [TIME <mstime>] [RETRYCOUNT <count>]
+    //     [FORCE] [JUSTID]
+
+    /// This is the optional arguments version for claiming unacked, pending messages
+    /// currently checked out by another consumer.
+    ///
+    /// ```no_run
+    /// use redis_streams::{client_open,Connection,RedisResult,StreamCommands,StreamClaimOptions,StreamClaimReply};
+    /// let client = client_open("redis://127.0.0.1/0").unwrap();
+    /// let mut con = client.get_connection().unwrap();
+    ///
+    /// // Claim all pending messages for key "k1",
+    /// // from group "g1", checked out by consumer "c1"
+    /// // for 10ms with RETRYCOUNT 2 and FORCE
+    ///
+    /// let opts = StreamClaimOptions::default()
+    ///     .with_force()
+    ///     .retry(2);
+    /// let results: RedisResult<StreamClaimReply> =
+    ///     con.xclaim_options("k1", "g1", "c1", 10, &["0"], opts);
+    ///
+    /// // All optional arguments return a `Result<StreamClaimReply>` with one exception:
+    /// // Passing JUSTID returns only the message `id` and omits the HashMap for each message.
+    ///
+    /// let opts = StreamClaimOptions::default()
+    ///     .with_justid();
+    /// let results: RedisResult<Vec<String>> =
+    ///     con.xclaim_options("k1", "g1", "c1", 10, &["0"], opts);
+    /// ```
+    ///
+    #[inline]
+    fn xclaim_options<
+        K: ToRedisArgs,
+        G: ToRedisArgs,
+        C: ToRedisArgs,
+        MIT: ToRedisArgs,
+        ID: ToRedisArgs,
+        RV: FromRedisValue,
+    >(
+        &mut self,
+        key: K,
+        group: G,
+        consumer: C,
+        min_idle_time: MIT,
+        ids: &[ID],
+        options: StreamClaimOptions,
+    ) -> RedisResult<RV> {
+        cmd("XCLAIM")
+            .arg(key)
+            .arg(group)
+            .arg(consumer)
+            .arg(min_idle_time)
+            .arg(ids)
+            .arg(options)
+            .query(self)
+    }
+
+    // XDEL <key> [<ID1> <ID2> ... <IDN>]
+
+    /// Deletes a list of `id`s for a given stream `key`.
+    ///
+    #[inline]
+    fn xdel<K: ToRedisArgs, ID: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        ids: &[ID],
+    ) -> RedisResult<RV> {
+        cmd("XDEL").arg(key).arg(ids).query(self)
+    }
+
+    // XGROUP CREATE <key> <groupname> <id or $>
+
+    /// This command is used for creating a consumer `group`. It expects the stream key
+    /// to already exist. Otherwise, use `xgroup_create_mkstream` if it doesn't.
+    /// The `id` is the starting message id all consumers should read from. Use `$` If you want
+    /// all consumers to read from the last message added to stream.
+    ///
+    #[inline]
+    fn xgroup_create<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        group: G,
+        id: ID,
+    ) -> RedisResult<RV> {
+        cmd("XGROUP")
+            .arg("CREATE")
+            .arg(key)
+            .arg(group)
+            .arg(id)
+            .query(self)
+    }
+
+    // XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]
+
+    /// This is the alternate version for creating a consumer `group`
+    /// which makes the stream if it doesn't exist.
+    ///
+    #[inline]
+    fn xgroup_create_mkstream<
+        K: ToRedisArgs,
+        G: ToRedisArgs,
+        ID: ToRedisArgs,
+        RV: FromRedisValue,
+    >(
+        &mut self,
+        key: K,
+        group: G,
+        id: ID,
+    ) -> RedisResult<RV> {
+        cmd("XGROUP")
+            .arg("CREATE")
+            .arg(key)
+            .arg(group)
+            .arg(id)
+            .arg("MKSTREAM")
+            .query(self)
+    }
+
+    // XGROUP SETID <key> <groupname> <id or $>
+
+    /// Alter which `id` you want consumers to begin reading from an existing
+    /// consumer `group`.
+    ///
+    #[inline]
+    fn xgroup_setid<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        group: G,
+        id: ID,
+    ) -> RedisResult<RV> {
+        cmd("XGROUP")
+            .arg("SETID")
+            .arg(key)
+            .arg(group)
+            .arg(id)
+            .query(self)
+    }
+
+    // XGROUP DESTROY <key> <groupname>
+
+    /// Destroy an existing consumer `group` for a given stream `key`
+    ///
+    #[inline]
+    fn xgroup_destroy<K: ToRedisArgs, G: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        group: G,
+    ) -> RedisResult<RV> {
+        cmd("XGROUP").arg("DESTROY").arg(key).arg(group).query(self)
+    }
+
+    // XGROUP DELCONSUMER <key> <groupname> <consumername>
+
+    /// This deletes a `consumer` from an existing consumer `group`
+    /// for given stream `key.
+    ///
+    #[inline]
+    fn xgroup_delconsumer<K: ToRedisArgs, G: ToRedisArgs, C: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        group: G,
+        consumer: C,
+    ) -> RedisResult<RV> {
+        cmd("XGROUP")
+            .arg("DELCONSUMER")
+            .arg(key)
+            .arg(group)
+            .arg(consumer)
+            .query(self)
+    }
+
+    // XINFO CONSUMERS <key> <group>
+
+    /// This returns all info details about
+    /// which consumers have read messages for given consumer `group`.
+    /// Take note of the StreamInfoConsumersReply return type.
+    ///
+    /// *It's possible this return value might not contain new fields
+    /// added by Redis in future versions.*
+    ///
+    #[inline]
+    fn xinfo_consumers<K: ToRedisArgs, G: ToRedisArgs>(
+        &mut self,
+        key: K,
+        group: G,
+    ) -> RedisResult<StreamInfoConsumersReply> {
+        cmd("XINFO")
+            .arg("CONSUMERS")
+            .arg(key)
+            .arg(group)
+            .query(self)
+    }
+
+    // XINFO GROUPS <key>
+
+    /// Returns all consumer `group`s created for a given stream `key`.
+    /// Take note of the StreamInfoGroupsReply return type.
+    ///
+    /// *It's possible this return value might not contain new fields
+    /// added by Redis in future versions.*
+    ///
+    #[inline]
+    fn xinfo_groups<K: ToRedisArgs>(&mut self, key: K) -> RedisResult<StreamInfoGroupsReply> {
+        cmd("XINFO").arg("GROUPS").arg(key).query(self)
+    }
+
+    // XINFO STREAM <key>
+
+    /// Returns info about high-level stream details
+    /// (first & last message `id`, length, number of groups, etc.)
+    /// Take note of the StreamInfoStreamReply return type.
+    ///
+    /// *It's possible this return value might not contain new fields
+    /// added by Redis in future versions.*
+    ///
+    #[inline]
+    fn xinfo_stream<K: ToRedisArgs>(&mut self, key: K) -> RedisResult<StreamInfoStreamReply> {
+        cmd("XINFO").arg("STREAM").arg(key).query(self)
+    }
+
+    // XLEN <key>
+    /// Returns the number of messages for a given stream `key`.
+    ///
+    #[inline]
+    fn xlen<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<RV> {
+        cmd("XLEN").arg(key).query(self)
+    }
+
+    // XPENDING <key> <group> [<start> <stop> <count> [<consumer>]]
+
+    /// This is basic version of making XPENDING command calls which only
+    /// passes a stream `key` and consumer `group` and it
+    /// returns details about which consumers have pending messages
+    /// that haven't been acked.
+    ///
+    /// You can use this method along with
+    /// `xclaim` or `xclaim_options` for determinging which messages
+    /// need to be retried.
+    ///
+    /// Take note of the StreamPendingReply return type.
+    ///
+    #[inline]
+    fn xpending<K: ToRedisArgs, G: ToRedisArgs>(
+        &mut self,
+        key: K,
+        group: G,
+    ) -> RedisResult<StreamPendingReply> {
+        cmd("XPENDING").arg(key).arg(group).query(self)
+    }
+
+    // XPENDING <key> <group> <start> <stop> <count>
+
+    /// This XPENDING version returns a list of all messages over the range.
+    /// You can use this for paginating pending messages (but without the message HashMap).
+    ///
+    /// Start and end follow the same rules `xrange` args. Set start to `-`
+    /// and end to `+` for the entire stream.
+    ///
+    /// Take note of the StreamPendingCountReply return type.
+    ///
+    #[inline]
+    fn xpending_count<
+        K: ToRedisArgs,
+        G: ToRedisArgs,
+        S: ToRedisArgs,
+        E: ToRedisArgs,
+        C: ToRedisArgs,
+    >(
+        &mut self,
+        key: K,
+        group: G,
+        start: S,
+        end: E,
+        count: C,
+    ) -> RedisResult<StreamPendingCountReply> {
+        cmd("XPENDING")
+            .arg(key)
+            .arg(group)
+            .arg(start)
+            .arg(end)
+            .arg(count)
+            .query(self)
+    }
+
+    // XPENDING <key> <group> <start> <stop> <count> <consumer>
+
+    /// An alternate version of `xpending_count` which filters by `consumer` name.
+    ///
+    /// Start and end follow the same rules `xrange` args. Set start to `-`
+    /// and end to `+` for the entire stream.
+    ///
+    /// Take note of the StreamPendingCountReply return type.
+    ///
+    #[inline]
+    fn xpending_consumer_count<
+        K: ToRedisArgs,
+        G: ToRedisArgs,
+        S: ToRedisArgs,
+        E: ToRedisArgs,
+        C: ToRedisArgs,
+        CN: ToRedisArgs,
+    >(
+        &mut self,
+        key: K,
+        group: G,
+        start: S,
+        end: E,
+        count: C,
+        consumer: CN,
+    ) -> RedisResult<StreamPendingCountReply> {
+        cmd("XPENDING")
+            .arg(key)
+            .arg(group)
+            .arg(start)
+            .arg(end)
+            .arg(count)
+            .arg(consumer)
+            .query(self)
+    }
+
+    // XRANGE key start end
+
+    /// Returns a range of messages in a given stream `key`.
+    ///
+    /// Set `start` to `-` to begin at the first message.
+    /// Set `end` to `+` to end the most recent message.
+    /// You can pass message `id` to both `start` and `end`.
+    ///
+    /// Take note of the StreamRangeReply return type.
+    ///
+    #[inline]
+    fn xrange<K: ToRedisArgs, S: ToRedisArgs, E: ToRedisArgs>(
+        &mut self,
+        key: K,
+        start: S,
+        end: E,
+    ) -> RedisResult<StreamRangeReply> {
+        cmd("XRANGE").arg(key).arg(start).arg(end).query(self)
+    }
+
+    // XRANGE key - +
+
+    /// A helper method for automatically returning all messages in a stream by `key`.
+    /// **Use with caution!**
+    ///
+    #[inline]
+    fn xrange_all<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<RV> {
+        cmd("XRANGE").arg(key).arg("-").arg("+").query(self)
+    }
+
+    // XRANGE key start end [COUNT <n>]
+
+    /// A method for paginating a stream by `key`.
+    ///
+    #[inline]
+    fn xrange_count<K: ToRedisArgs, S: ToRedisArgs, E: ToRedisArgs, C: ToRedisArgs>(
+        &mut self,
+        key: K,
+        start: S,
+        end: E,
+        count: C,
+    ) -> RedisResult<StreamRangeReply> {
+        cmd("XRANGE")
+            .arg(key)
+            .arg(start)
+            .arg(end)
+            .arg("COUNT")
+            .arg(count)
+            .query(self)
+    }
+
+    // XREAD STREAMS key_1 key_2 ... key_N ID_1 ID_2 ... ID_N
+
+    /// Read a list of `id`s for each stream `key`.
+    /// This is the basic form of reading streams.
+    /// For more advanced control, like blocking, limiting, or reading by consumer `group`,
+    /// see `xread_options`.
+    ///
+    #[inline]
+    fn xread<K: ToRedisArgs, ID: ToRedisArgs>(
+        &mut self,
+        keys: &[K],
+        ids: &[ID],
+    ) -> RedisResult<StreamReadReply> {
+        cmd("XREAD").arg("STREAMS").arg(keys).arg(ids).query(self)
+    }
+
+    // XREAD [BLOCK <milliseconds>] [COUNT <count>]
+    //       STREAMS key_1 key_2 ... key_N
+    //       ID_1 ID_2 ... ID_N
+    // XREADGROUP [BLOCK <milliseconds>] [COUNT <count>] [GROUP group-name consumer-name]
+    //       STREAMS key_1 key_2 ... key_N
+    //       ID_1 ID_2 ... ID_N
+
+    /// This method handles setting optional arguments for
+    /// `XREAD` or `XREADGROUP` Redis commands.
+    /// ```no_run
+    /// use redis_streams::{client_open,Connection,RedisResult,StreamCommands,StreamReadOptions,StreamReadReply};
+    /// let client = client_open("redis://127.0.0.1/0").unwrap();
+    /// let mut con = client.get_connection().unwrap();
+    ///
+    /// // Read 10 messages from the start of the stream,
+    /// // without registering as a consumer group.
+    ///
+    /// let opts = StreamReadOptions::default()
+    ///     .count(10);
+    /// let results: RedisResult<StreamReadReply> =
+    ///     con.xread_options(&["k1"], &["0"], opts);
+    ///
+    /// // Read all undelivered messages for a given
+    /// // consumer group. Be advised: the consumer group must already
+    /// // exist before making this call. Also note: we're passing
+    /// // '>' as the id here, which means all underlivered messages.
+    ///
+    /// let opts = StreamReadOptions::default()
+    ///     .group("group-1", "consumer-1");
+    /// let results: RedisResult<StreamReadReply> =
+    ///     con.xread_options(&["k1"], &[">"], opts);
+    /// ```
+    ///
+    #[inline]
+    fn xread_options<K: ToRedisArgs, ID: ToRedisArgs>(
+        &mut self,
+        keys: &[K],
+        ids: &[ID],
+        options: StreamReadOptions,
+    ) -> RedisResult<StreamReadReply> {
+        cmd(if options.read_only() {
+            "XREAD"
+        } else {
+            "XREADGROUP"
+        })
+        .arg(options)
+        .arg("STREAMS")
+        .arg(keys)
+        .arg(ids)
+        .query(self)
+    }
+
+    // XREVRANGE key end start
+
+    /// This is the reverse version of `xrange`.
+    /// The same rules apply for `start` and `end` here.
+    ///
+    #[inline]
+    fn xrevrange<K: ToRedisArgs, E: ToRedisArgs, S: ToRedisArgs>(
+        &mut self,
+        key: K,
+        end: E,
+        start: S,
+    ) -> RedisResult<StreamRangeReply> {
+        cmd("XREVRANGE").arg(key).arg(end).arg(start).query(self)
+    }
+
+    // XREVRANGE key + -
+
+    /// This is the reverse version of `xrange_all`.
+    /// The same rules apply for `start` and `end` here.
+    ///
+    fn xrevrange_all<K: ToRedisArgs>(&mut self, key: K) -> RedisResult<StreamRangeReply> {
+        cmd("XREVRANGE").arg(key).arg("+").arg("-").query(self)
+    }
+
+    // XREVRANGE key end start [COUNT <n>]
+
+    /// This is the reverse version of `xrange_count`.
+    /// The same rules apply for `start` and `end` here.
+    ///
+    #[inline]
+    fn xrevrange_count<K: ToRedisArgs, E: ToRedisArgs, S: ToRedisArgs, C: ToRedisArgs>(
+        &mut self,
+        key: K,
+        end: E,
+        start: S,
+        count: C,
+    ) -> RedisResult<StreamRangeReply> {
+        cmd("XREVRANGE")
+            .arg(key)
+            .arg(end)
+            .arg(start)
+            .arg("COUNT")
+            .arg(count)
+            .query(self)
+    }
+
+    // XTRIM <key> MAXLEN [~|=] <count>  (Same as XADD MAXLEN option)
+
+    /// Trim a stream `key` to a MAXLEN count.
+    ///
+    #[inline]
+    fn xtrim<K: ToRedisArgs, RV: FromRedisValue>(
+        &mut self,
+        key: K,
+        maxlen: StreamMaxlen,
+    ) -> RedisResult<RV> {
+        cmd("XTRIM").arg(key).arg(maxlen).query(self)
+    }
+}
+
+impl<T> StreamCommands for T where T: ConnectionLike {}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,6 @@ use crate::types::{
 
 use redis::{cmd, ConnectionLike, FromRedisValue, RedisResult, ToRedisArgs};
 
-
 /// Implementation of all redis stream commands.
 ///
 pub trait StreamCommands: ConnectionLike + Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 #[doc(hidden)]
 pub extern crate redis;
 
-pub use redis::{Commands,Connection,RedisResult};
+pub use redis::{Commands, Connection, RedisResult};
 
 pub use commands::StreamCommands;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,63 @@
+//! `redis-streams-rs` exposes the [Redis Stream](https://redis.io/commands#stream)
+//! functionality as a Trait on top of [`redis-rs`](https://github.com/mitsuhiko/redis-rs).
+//!
+//! The crate is called `redis_streams`.
+//!
+//! In order to you use this crate, you'll first want to add it as a github
+//! dependency (until I have a chance to publish on crates.io).
+//!
+//! ```ini
+//! [dependencies.redis_streams]
+//! git = "https://github.com/grippy/redis-streams-rs.git"
+//! ```
+//!
+//! From here, just unlock the streaming commands prior to instantiating client connections.
+//!
+//! ```no_run
+//! extern crate redis_streams;
+//! use redis_streams::{client_open,Connection,StreamCommands};
+//! let client = client_open("redis://127.0.0.1/0").unwrap();
+//! let mut con = client.get_connection().unwrap();
+//! ```
+//!
+//! This crate also exposes all top-level `redis-rs` types.
+//! To pick up all `redis-rs` Commands, just use the `Commands` trait.
+//!
+//! ```no_run
+//! extern crate redis_streams;
+//! use redis_streams::{Commands};
+//! ```
+//!
+#![deny(non_camel_case_types)]
+
+extern crate redis;
+
+pub use redis::*;
+
+pub use commands::StreamCommands;
+
+pub use types::{
+    // stream types
+    StreamClaimOptions,
+    StreamClaimReply,
+    StreamId,
+    StreamInfoConsumersReply,
+    StreamInfoGroupsReply,
+    StreamInfoStreamReply,
+    StreamKey,
+    StreamMaxlen,
+    StreamPendingCountReply,
+    StreamPendingReply,
+    StreamRangeReply,
+    StreamReadOptions,
+    StreamReadReply,
+};
+
+mod commands;
+mod types;
+
+/// Curry `redis::Client::open` calls.
+///
+pub fn client_open<T: redis::IntoConnectionInfo>(params: T) -> redis::RedisResult<redis::Client> {
+    redis::Client::open(params)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,10 @@
 //!
 #![deny(non_camel_case_types)]
 
-extern crate redis;
+#[doc(hidden)]
+pub extern crate redis;
 
-pub use redis::*;
+pub use redis::{Commands,Connection,RedisResult};
 
 pub use commands::StreamCommands;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,17 @@ use redis::{from_redis_value, FromRedisValue, RedisResult, RedisWrite, ToRedisAr
 
 use std::collections::HashMap;
 
+
+// fn itoa_usize_fmt(i: usize) -> Vec<u8> {
+//     let mut buffer = itoa::Buffer::new();
+//     let printed = buffer.format(1234);
+//     assert_eq!(printed, "1234");
+// }
+
+
+
+
+
 // Stream Maxlen Enum
 
 /// Utility enum for passing `MAXLEN [= or ~] [COUNT]`
@@ -24,7 +35,7 @@ impl ToRedisArgs for StreamMaxlen {
         };
         out.write_arg("MAXLEN".as_bytes());
         out.write_arg(ch.as_bytes());
-        out.write_arg(format!("{}", val).as_bytes());
+        val.write_redis_args(out);
     }
 }
 
@@ -315,11 +326,11 @@ impl StreamId {
         let mut stream_id = StreamId::default();
         match *v {
             Value::Bulk(ref values) => {
-                if values.len() >= 1 {
-                    stream_id.id = from_redis_value(&values[0])?;
+                if let Some(v) = values.get(0) {
+                    stream_id.id = from_redis_value(&v)?;
                 }
-                if values.len() >= 2 {
-                    stream_id.map = from_redis_value(&values[1])?;
+                if let Some(v) = values.get(1) {
+                    stream_id.map = from_redis_value(&v)?;
                 }
             }
             _ => {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,17 +2,6 @@ use redis::{from_redis_value, FromRedisValue, RedisResult, RedisWrite, ToRedisAr
 
 use std::collections::HashMap;
 
-
-// fn itoa_usize_fmt(i: usize) -> Vec<u8> {
-//     let mut buffer = itoa::Buffer::new();
-//     let printed = buffer.format(1234);
-//     assert_eq!(printed, "1234");
-// }
-
-
-
-
-
 // Stream Maxlen Enum
 
 /// Utility enum for passing `MAXLEN [= or ~] [COUNT]`

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,512 @@
+use redis::{from_redis_value, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, Value};
+
+use std::collections::HashMap;
+
+// Stream Maxlen Enum
+
+/// Utility enum for passing `MAXLEN [= or ~] [COUNT]`
+/// arguments into `StreamCommands`.
+/// The enum value represents the count.
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
+pub enum StreamMaxlen {
+    Equals(usize),
+    Aprrox(usize),
+}
+
+impl ToRedisArgs for StreamMaxlen {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        let (ch, val) = match *self {
+            StreamMaxlen::Equals(v) => ("=", v),
+            StreamMaxlen::Aprrox(v) => ("~", v),
+        };
+        out.write_arg("MAXLEN".as_bytes());
+        out.write_arg(ch.as_bytes());
+        out.write_arg(format!("{}", val).as_bytes());
+    }
+}
+
+/// Builder options for [`xclaim_options`] command.
+///
+/// [`xclaim_options`]: ./trait.StreamCommands.html#method.xclaim_options
+///
+#[derive(Default, Debug)]
+pub struct StreamClaimOptions {
+    /// Set IDLE <milliseconds> cmd arg.
+    idle: Option<usize>,
+    /// Set IDLE <mstime> cmd arg.
+    time: Option<usize>,
+    /// Set RETRYCOUNT <count> cmd arg.
+    retry: Option<usize>,
+    /// Set FORCE cmd arg.
+    force: bool,
+    /// Set JUSTID cmd arg. Be advised: the response
+    /// type changes with this option.
+    justid: bool,
+}
+
+impl StreamClaimOptions {
+    pub fn idle(mut self, ms: usize) -> Self {
+        self.idle = Some(ms);
+        self
+    }
+
+    pub fn time(mut self, ms_time: usize) -> Self {
+        self.time = Some(ms_time);
+        self
+    }
+
+    pub fn retry(mut self, count: usize) -> Self {
+        self.retry = Some(count);
+        self
+    }
+
+    pub fn with_force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+
+    pub fn with_justid(mut self) -> Self {
+        self.justid = true;
+        self
+    }
+}
+
+impl ToRedisArgs for StreamClaimOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(ref ms) = self.idle {
+            out.write_arg("IDLE".as_bytes());
+            out.write_arg(format!("{}", ms).as_bytes());
+        }
+        if let Some(ref ms_time) = self.time {
+            out.write_arg("TIME".as_bytes());
+            out.write_arg(format!("{}", ms_time).as_bytes());
+        }
+        if let Some(ref count) = self.retry {
+            out.write_arg("RETRYCOUNT".as_bytes());
+            out.write_arg(format!("{}", count).as_bytes());
+        }
+        if self.force {
+            out.write_arg("FORCE".as_bytes());
+        }
+        if self.justid {
+            out.write_arg("JUSTID".as_bytes());
+        }
+    }
+}
+
+/// Builder options for [`xread_options`] command.
+///
+/// [`xread_options`]: ./trait.StreamCommands.html#method.xread_options
+///
+#[derive(Default, Debug)]
+pub struct StreamReadOptions {
+    /// Set the BLOCK <milliseconds> cmd arg.
+    block: Option<usize>,
+    /// Set the COUNT <count> cmd arg.
+    count: Option<usize>,
+    /// Set the GROUP <groupname> <consumername> cmd arg.
+    /// This option will toggle the cmd from XREAD to XREADGROUP.
+    group: Option<(Vec<Vec<u8>>, Vec<Vec<u8>>)>,
+}
+
+impl StreamReadOptions {
+    pub fn read_only(&self) -> bool {
+        self.group.is_none()
+    }
+
+    pub fn block(mut self, ms: usize) -> Self {
+        self.block = Some(ms);
+        self
+    }
+
+    pub fn count(mut self, n: usize) -> Self {
+        self.count = Some(n);
+        self
+    }
+
+    pub fn group<GN: ToRedisArgs, CN: ToRedisArgs>(
+        mut self,
+        group_name: GN,
+        consumer_name: CN,
+    ) -> Self {
+        self.group = Some((
+            ToRedisArgs::to_redis_args(&group_name),
+            ToRedisArgs::to_redis_args(&consumer_name),
+        ));
+        self
+    }
+}
+
+impl ToRedisArgs for StreamReadOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(ref ms) = self.block {
+            out.write_arg("BLOCK".as_bytes());
+            out.write_arg(format!("{}", ms).as_bytes());
+        }
+
+        if let Some(ref n) = self.count {
+            out.write_arg("COUNT".as_bytes());
+            out.write_arg(format!("{}", n).as_bytes());
+        }
+
+        if let Some(ref group) = self.group {
+            out.write_arg("GROUP".as_bytes());
+            for i in &group.0 {
+                out.write_arg(i);
+            }
+            for i in &group.1 {
+                out.write_arg(i);
+            }
+        }
+    }
+}
+
+/// Reply type used with [`xread`] or [`xread_options`] commands.
+///
+/// [`xread`]: ./trait.StreamCommands.html#method.xread
+/// [`xread_options`]: ./trait.StreamCommands.html#method.xread_options
+///
+#[derive(Default, Debug)]
+pub struct StreamReadReply {
+    pub keys: Vec<StreamKey>,
+}
+
+/// Reply type used with [`xrange`], [`xrange_count`], [`xrange_all`], [`xrevrange`], [`xrevrange_count`], [`xrevrange_all`] commands.
+///
+/// [`xrange`]: ./trait.StreamCommands.html#method.xrange
+/// [`xrange_count`]: ./trait.StreamCommands.html#method.xrange_count
+/// [`xrange_all`]: ./trait.StreamCommands.html#method.xrange_all
+/// [`xrevrange`]: ./trait.StreamCommands.html#method.xrevrange
+/// [`xrevrange_count`]: ./trait.StreamCommands.html#method.xrevrange_count
+/// [`xrevrange_all`]: ./trait.StreamCommands.html#method.xrevrange_all
+///
+#[derive(Default, Debug)]
+pub struct StreamRangeReply {
+    pub ids: Vec<StreamId>,
+}
+
+/// Reply type used with [`xclaim`] command.
+///
+/// [`xclaim`]: ./trait.StreamCommands.html#method.xclaim
+///
+#[derive(Default, Debug)]
+pub struct StreamClaimReply {
+    pub ids: Vec<StreamId>,
+}
+
+/// Reply type used with [`xpending`] command.
+///
+/// [`xpending`]: ./trait.StreamCommands.html#method.xpending
+///
+#[derive(Default, Debug)]
+pub struct StreamPendingReply {
+    pub count: usize,
+    pub start_id: String,
+    pub end_id: String,
+    pub consumers: Vec<StreamInfoConsumer>,
+}
+
+/// Reply type use with [`xpending_count`] and
+/// [`xpending_consumer_count`] commands.
+///
+/// [`xpending_count`]: ./trait.StreamCommands.html#method.xpending_count
+/// [`xpending_consumer_count`]: ./trait.StreamCommands.html#method.xpending_consumer_count
+///
+#[derive(Default, Debug)]
+pub struct StreamPendingCountReply {
+    pub ids: Vec<StreamPendingId>,
+}
+
+/// Reply type used with [`xinfo_stream`] command.
+///
+/// [`xinfo_stream`]: ./trait.StreamCommands.html#method.xinfo_stream
+///
+#[derive(Default, Debug)]
+pub struct StreamInfoStreamReply {
+    pub last_generated_id: String,
+    pub radix_tree_keys: usize,
+    pub groups: usize,
+    pub length: usize,
+    pub first_entry: StreamId,
+    pub last_entry: StreamId,
+}
+
+/// Reply type used with [`xinfo_consumer`] command.
+///
+/// [`xinfo_consumer`]: ./trait.StreamCommands.html#method.xinfo_consumer
+///
+#[derive(Default, Debug)]
+pub struct StreamInfoConsumersReply {
+    pub consumers: Vec<StreamInfoConsumer>,
+}
+
+/// Reply type used with [`xinfo_groups`] command.
+///
+/// [`xinfo_groups`]: ./trait.StreamCommands.html#method.xinfo_groups
+///
+#[derive(Default, Debug)]
+pub struct StreamInfoGroupsReply {
+    pub groups: Vec<StreamInfoGroup>,
+}
+
+/// A consumer parsed from [`xinfo_consumers`] command.
+///
+/// [`xinfo_consumers`]: ./trait.StreamCommands.html#method.xinfo_consumers
+///
+#[derive(Default, Debug)]
+pub struct StreamInfoConsumer {
+    pub name: String,
+    pub pending: usize,
+    pub idle: usize,
+}
+
+/// A group parsed from [`xinfo_groups`] command.
+///
+/// [`xinfo_groups`]: ./trait.StreamCommands.html#method.xinfo_groups
+///
+#[derive(Default, Debug)]
+pub struct StreamInfoGroup {
+    pub name: String,
+    pub consumers: usize,
+    pub pending: usize,
+    pub last_delivered_id: String,
+}
+
+/// Represents a pending message parsed from `xpending` methods.
+#[derive(Default, Debug)]
+pub struct StreamPendingId {
+    pub id: String,
+    pub consumer: String,
+    pub last_delivered_ms: usize,
+    pub times_delivered: usize,
+}
+
+/// Represents a stream `key` and its `id`'s parsed from `xread` methods.
+#[derive(Default, Debug)]
+pub struct StreamKey {
+    pub key: String,
+    pub ids: Vec<StreamId>,
+}
+
+impl StreamKey {
+    pub fn just_ids(&self) -> Vec<&String> {
+        self.ids.iter().map(|msg| &msg.id).collect::<Vec<&String>>()
+    }
+}
+
+/// Represents a stream `id` and its field/values as a `HashMap`
+#[derive(Default, Debug)]
+pub struct StreamId {
+    pub id: String,
+    pub map: HashMap<String, Value>,
+}
+
+impl StreamId {
+    pub fn from_bulk_value(v: &Value) -> RedisResult<Self> {
+        let mut stream_id = StreamId::default();
+        match *v {
+            Value::Bulk(ref values) => {
+                if values.len() >= 1 {
+                    stream_id.id = from_redis_value(&values[0])?;
+                }
+                if values.len() >= 2 {
+                    stream_id.map = from_redis_value(&values[1])?;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(stream_id)
+    }
+
+    pub fn get<T: FromRedisValue>(&self, key: &str) -> Option<T> {
+        match self.find(&key) {
+            Some(ref x) => from_redis_value(*x).ok(),
+            None => None,
+        }
+    }
+
+    pub fn find(&self, key: &&str) -> Option<&Value> {
+        self.map.get(*key)
+    }
+
+    pub fn contains_key(&self, key: &&str) -> bool {
+        self.find(key).is_some()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+impl FromRedisValue for StreamReadReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let rows: Vec<HashMap<String, Vec<HashMap<String, HashMap<String, Value>>>>> =
+            from_redis_value(v)?;
+        let mut reply = StreamReadReply::default();
+        for row in &rows {
+            for (key, entry) in row.iter() {
+                let mut k = StreamKey::default();
+                k.key = key.to_owned();
+                for id_row in entry {
+                    let mut i = StreamId::default();
+                    for (id, map) in id_row.iter() {
+                        i.id = id.to_owned();
+                        i.map = map.to_owned();
+                    }
+                    k.ids.push(i);
+                }
+                reply.keys.push(k);
+            }
+        }
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamRangeReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let rows: Vec<HashMap<String, HashMap<String, Value>>> = from_redis_value(v)?;
+        let mut reply = StreamRangeReply::default();
+        for row in &rows {
+            let mut i = StreamId::default();
+            for (id, map) in row.iter() {
+                i.id = id.to_owned();
+                i.map = map.to_owned();
+            }
+            reply.ids.push(i);
+        }
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamClaimReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let rows: Vec<HashMap<String, HashMap<String, Value>>> = from_redis_value(v)?;
+        let mut reply = StreamClaimReply::default();
+        for row in &rows {
+            let mut i = StreamId::default();
+            for (id, map) in row.iter() {
+                i.id = id.to_owned();
+                i.map = map.to_owned();
+            }
+            reply.ids.push(i);
+        }
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamPendingReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let parts: (usize, String, String, Vec<Vec<String>>) = from_redis_value(v)?;
+        let mut reply = StreamPendingReply::default();
+        reply.count = parts.0.to_owned() as usize;
+        reply.start_id = parts.1.to_owned();
+        reply.end_id = parts.2.to_owned();
+        for consumer in &parts.3 {
+            let mut info = StreamInfoConsumer::default();
+            info.name = consumer[0].to_owned();
+            if let Ok(v) = consumer[1].to_owned().parse::<usize>() {
+                info.pending = v;
+            }
+            reply.consumers.push(info);
+        }
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamPendingCountReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let parts: Vec<Vec<(String, String, usize, usize)>> = from_redis_value(v)?;
+        let mut reply = StreamPendingCountReply::default();
+        for row in &parts {
+            let mut p = StreamPendingId::default();
+            p.id = row[0].0.to_owned();
+            p.consumer = row[0].1.to_owned();
+            p.last_delivered_ms = row[0].2.to_owned();
+            p.times_delivered = row[0].3.to_owned();
+            reply.ids.push(p);
+        }
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamInfoStreamReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let map: HashMap<String, Value> = from_redis_value(v)?;
+        let mut reply = StreamInfoStreamReply::default();
+        if let Some(v) = &map.get("last-generated-id") {
+            reply.last_generated_id = from_redis_value(v)?;
+        }
+        if let Some(v) = &map.get("radix-tree-nodes") {
+            reply.radix_tree_keys = from_redis_value(v)?;
+        }
+        if let Some(v) = &map.get("groups") {
+            reply.groups = from_redis_value(v)?;
+        }
+        if let Some(v) = &map.get("length") {
+            reply.length = from_redis_value(v)?;
+        }
+        if let Some(v) = &map.get("first-entry") {
+            reply.first_entry = StreamId::from_bulk_value(v)?;
+        }
+        if let Some(v) = &map.get("last-entry") {
+            reply.last_entry = StreamId::from_bulk_value(v)?;
+        }
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamInfoConsumersReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let consumers: Vec<HashMap<String, Value>> = from_redis_value(v)?;
+        let mut reply = StreamInfoConsumersReply::default();
+        for map in consumers {
+            let mut c = StreamInfoConsumer::default();
+            if let Some(v) = &map.get("name") {
+                c.name = from_redis_value(v)?;
+            }
+            if let Some(v) = &map.get("pending") {
+                c.pending = from_redis_value(v)?;
+            }
+            if let Some(v) = &map.get("idle") {
+                c.idle = from_redis_value(v)?;
+            }
+            reply.consumers.push(c);
+        }
+
+        Ok(reply)
+    }
+}
+
+impl FromRedisValue for StreamInfoGroupsReply {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let groups: Vec<HashMap<String, Value>> = from_redis_value(v)?;
+        let mut reply = StreamInfoGroupsReply::default();
+        for map in groups {
+            let mut g = StreamInfoGroup::default();
+            if let Some(v) = &map.get("name") {
+                g.name = from_redis_value(v)?;
+            }
+            if let Some(v) = &map.get("pending") {
+                g.pending = from_redis_value(v)?;
+            }
+            if let Some(v) = &map.get("consumers") {
+                g.consumers = from_redis_value(v)?;
+            }
+            if let Some(v) = &map.get("last-delivered-id") {
+                g.last_delivered_id = from_redis_value(v)?;
+            }
+            reply.groups.push(g);
+        }
+        Ok(reply)
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,162 @@
+// This file is mostly a direct copy of this file in redis-rs.
+// all the async code has been removed for now...
+// https://github.com/mitsuhiko/redis-rs/blob/master/tests/support/mod.rs
+
+#![allow(dead_code)]
+
+extern crate net2;
+extern crate rand;
+
+use redis;
+
+use std::env;
+use std::fs;
+use std::process;
+use std::thread::sleep;
+use std::time::Duration;
+
+use std::path::PathBuf;
+
+#[derive(PartialEq)]
+enum ServerType {
+    Tcp,
+    Unix,
+}
+
+pub struct RedisServer {
+    pub process: process::Child,
+    addr: redis::ConnectionAddr,
+}
+
+impl ServerType {
+    fn get_intended() -> ServerType {
+        match env::var("REDISRS_SERVER_TYPE")
+            .ok()
+            .as_ref()
+            .map(|x| &x[..])
+        {
+            Some("tcp") => ServerType::Tcp,
+            Some("unix") => ServerType::Unix,
+            val => {
+                panic!("Unknown server type {:?}", val);
+            }
+        }
+    }
+}
+
+impl RedisServer {
+    pub fn new() -> RedisServer {
+        let server_type = ServerType::get_intended();
+        let mut cmd = process::Command::new("redis-server");
+        cmd.stdout(process::Stdio::null())
+            .stderr(process::Stdio::null());
+
+        let addr = match server_type {
+            ServerType::Tcp => {
+                // this is technically a race but we can't do better with
+                // the tools that redis gives us :(
+                let listener = net2::TcpBuilder::new_v4()
+                    .unwrap()
+                    .reuse_address(true)
+                    .unwrap()
+                    .bind("127.0.0.1:0")
+                    .unwrap()
+                    .listen(1)
+                    .unwrap();
+                let server_port = listener.local_addr().unwrap().port();
+                cmd.arg("--port")
+                    .arg(server_port.to_string())
+                    .arg("--bind")
+                    .arg("127.0.0.1");
+                redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), server_port)
+            }
+            ServerType::Unix => {
+                let (a, b) = rand::random::<(u64, u64)>();
+                let path = format!("/tmp/redis-rs-test-{}-{}.sock", a, b);
+                cmd.arg("--port").arg("0").arg("--unixsocket").arg(&path);
+                redis::ConnectionAddr::Unix(PathBuf::from(&path))
+            }
+        };
+
+        let process = cmd.spawn().unwrap();
+        RedisServer {
+            process: process,
+            addr: addr,
+        }
+    }
+
+    pub fn wait(&mut self) {
+        self.process.wait().unwrap();
+    }
+
+    pub fn get_client_addr(&self) -> &redis::ConnectionAddr {
+        &self.addr
+    }
+
+    pub fn stop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+        match *self.get_client_addr() {
+            redis::ConnectionAddr::Unix(ref path) => {
+                fs::remove_file(&path).ok();
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Drop for RedisServer {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+pub struct TestContext {
+    pub server: RedisServer,
+    pub client: redis::Client,
+}
+
+impl TestContext {
+    pub fn new() -> TestContext {
+        let server = RedisServer::new();
+
+        let client = redis::Client::open(redis::ConnectionInfo {
+            addr: Box::new(server.get_client_addr().clone()),
+            db: 0,
+            passwd: None,
+        })
+        .unwrap();
+        let mut con;
+
+        let millisecond = Duration::from_millis(1);
+        loop {
+            match client.get_connection() {
+                Err(err) => {
+                    if err.is_connection_refusal() {
+                        sleep(millisecond);
+                    } else {
+                        panic!("Could not connect: {}", err);
+                    }
+                }
+                Ok(x) => {
+                    con = x;
+                    break;
+                }
+            }
+        }
+        redis::cmd("FLUSHDB").execute(&mut con);
+
+        TestContext {
+            server: server,
+            client: client,
+        }
+    }
+
+    pub fn connection(&self) -> redis::Connection {
+        self.client.get_connection().unwrap()
+    }
+
+    pub fn stop_server(&mut self) {
+        self.server.stop();
+    }
+}

--- a/tests/test_streams.rs
+++ b/tests/test_streams.rs
@@ -1,0 +1,526 @@
+extern crate redis;
+extern crate redis_streams;
+
+use redis::{Connection, RedisResult, ToRedisArgs};
+
+use redis_streams::{
+    StreamClaimOptions, StreamClaimReply, StreamCommands, StreamInfoConsumersReply,
+    StreamInfoGroupsReply, StreamInfoStreamReply, StreamMaxlen, StreamPendingCountReply,
+    StreamPendingReply, StreamRangeReply, StreamReadOptions, StreamReadReply,
+};
+
+use std::collections::BTreeMap;
+use std::str;
+use std::thread::sleep;
+use std::time::Duration;
+
+use support::*;
+
+mod support;
+
+macro_rules! assert_args {
+    ($value:expr, $($args:expr),+) => {
+        let args = $value.to_redis_args();
+        let strings: Vec<_> = args.iter()
+                                .map(|a| str::from_utf8(a.as_ref()).unwrap())
+                                .collect();
+        assert_eq!(strings, vec![$($args),+]);
+    }
+}
+
+fn xadd(con: &mut Connection) {
+    let _: RedisResult<String> =
+        con.xadd("k1", "1000-0", &[("hello", "world"), ("redis", "streams")]);
+    let _: RedisResult<String> = con.xadd("k1", "1000-1", &[("hello", "world2")]);
+    let _: RedisResult<String> = con.xadd("k2", "2000-0", &[("hello", "world")]);
+    let _: RedisResult<String> = con.xadd("k2", "2000-1", &[("hello", "world2")]);
+}
+
+fn xadd_keyrange(con: &mut Connection, key: &str, start: i32, end: i32) {
+    for _i in start..end {
+        let _: RedisResult<String> = con.xadd(key, "*", &[("h", "w")]);
+    }
+}
+
+#[test]
+fn test_cmd_options() {
+    // Tests the following command option builders....
+    // xclaim_options
+    // xread_options
+    // maxlen enum
+
+    // test read options
+
+    let empty = StreamClaimOptions::default();
+    assert_eq!(ToRedisArgs::to_redis_args(&empty).len(), 0);
+
+    let empty = StreamReadOptions::default();
+    assert_eq!(ToRedisArgs::to_redis_args(&empty).len(), 0);
+
+    let opts = StreamClaimOptions::default()
+        .idle(50)
+        .time(500)
+        .retry(3)
+        .with_force()
+        .with_justid();
+
+    assert_args!(
+        &opts,
+        "IDLE",
+        "50",
+        "TIME",
+        "500",
+        "RETRYCOUNT",
+        "3",
+        "FORCE",
+        "JUSTID"
+    );
+
+    // test maxlen options
+
+    assert_args!(StreamMaxlen::Aprrox(10), "MAXLEN", "~", "10");
+    assert_args!(StreamMaxlen::Equals(10), "MAXLEN", "=", "10");
+
+    // test read options
+
+    let opts = StreamReadOptions::default()
+        .block(100)
+        .count(200)
+        .group("group-name", "consumer-name");
+
+    assert_args!(
+        &opts,
+        "BLOCK",
+        "100",
+        "COUNT",
+        "200",
+        "GROUP",
+        "group-name",
+        "consumer-name"
+    );
+}
+
+#[test]
+fn test_assorted_1() {
+    // Tests the following commands....
+    // xadd
+    // xadd_map (skip this for now)
+    // xadd_maxlen
+    // xread
+    // xlen
+
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    xadd(&mut con);
+
+    // smoke test that we get the same id back
+    let result: RedisResult<String> = con.xadd("k0", "1000-0", &[("x", "y")]);
+    assert_eq!(result.unwrap(), "1000-0");
+
+    // xread reply
+    let reply: StreamReadReply = con.xread(&["k1", "k2", "k3"], &["0", "0", "0"]).unwrap();
+
+    // verify reply contains 2 keys even though we asked for 3
+    assert_eq!(&reply.keys.len(), &2usize);
+
+    // verify first key & first id exist
+    assert_eq!(&reply.keys[0].key, "k1");
+    assert_eq!(&reply.keys[0].ids.len(), &2usize);
+    assert_eq!(&reply.keys[0].ids[0].id, "1000-0");
+
+    // lookup the key in StreamId map
+    let hello: Option<String> = reply.keys[0].ids[0].get("hello");
+    assert_eq!(hello, Some("world".to_string()));
+
+    // verify the second key was written
+    assert_eq!(&reply.keys[1].key, "k2");
+    assert_eq!(&reply.keys[1].ids.len(), &2usize);
+    assert_eq!(&reply.keys[1].ids[0].id, "2000-0");
+
+    // test xadd_map
+    let mut map: BTreeMap<&str, &str> = BTreeMap::new();
+    map.insert("ab", "cd");
+    map.insert("ef", "gh");
+    map.insert("ij", "kl");
+    let _: RedisResult<String> = con.xadd_map("k3", "3000-0", map);
+
+    let reply: StreamRangeReply = con.xrange_all("k3").unwrap();
+    assert_eq!(reply.ids[0].contains_key(&"ab"), true);
+    assert_eq!(reply.ids[0].contains_key(&"ef"), true);
+    assert_eq!(reply.ids[0].contains_key(&"ij"), true);
+
+    // test xadd w/ maxlength below...
+
+    // add 100 things to k4
+    xadd_keyrange(&mut con, "k4", 0, 100);
+
+    // test xlen.. should have 100 items
+    let result: RedisResult<usize> = con.xlen("k4");
+    assert_eq!(result, Ok(100));
+
+    // test xadd_maxlen
+    let _: RedisResult<String> =
+        con.xadd_maxlen("k4", StreamMaxlen::Equals(10), "*", &[("h", "w")]);
+    let result: RedisResult<usize> = con.xlen("k4");
+    assert_eq!(result, Ok(10));
+}
+
+#[test]
+fn test_assorted_2() {
+    // Tests the following commands....
+    // xadd
+    // xinfo_stream
+    // xinfo_groups
+    // xinfo_consumer
+    // xgroup_create
+    // xgroup_create_mkstream
+    // xread_options
+    // xack
+    // xpending
+    // xpending_count
+    // xpending_consumer_count
+
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    xadd(&mut con);
+
+    // no key exists... this call breaks the connection pipe for some reason
+    let reply: RedisResult<StreamInfoStreamReply> = con.xinfo_stream("k10");
+    assert_eq!(reply.is_err(), true);
+
+    // redo the connection because the above error
+    con = ctx.connection();
+
+    // key should exist
+    let reply: StreamInfoStreamReply = con.xinfo_stream("k1").unwrap();
+    assert_eq!(&reply.first_entry.id, "1000-0");
+    assert_eq!(&reply.last_entry.id, "1000-1");
+    assert_eq!(&reply.last_generated_id, "1000-1");
+
+    // xgroup create (existing stream)
+    let result: RedisResult<String> = con.xgroup_create("k1", "g1", "$");
+    assert_eq!(result.is_ok(), true);
+
+    // xinfo groups (existing stream)
+    let result: RedisResult<StreamInfoGroupsReply> = con.xinfo_groups("k1");
+    assert_eq!(result.is_ok(), true);
+    let reply = result.unwrap();
+    assert_eq!(&reply.groups.len(), &1);
+    assert_eq!(&reply.groups[0].name, &"g1");
+
+    // test xgroup create w/ mkstream @ 0
+    let result: RedisResult<String> = con.xgroup_create_mkstream("k99", "g99", "0");
+    assert_eq!(result.is_ok(), true);
+
+    // Since nothing exists on this stream yet,
+    // it should have the defaults returned by the client
+    let result: RedisResult<StreamInfoGroupsReply> = con.xinfo_groups("k99");
+    assert_eq!(result.is_ok(), true);
+    let reply = result.unwrap();
+    assert_eq!(&reply.groups.len(), &1);
+    assert_eq!(&reply.groups[0].name, &"g99");
+    assert_eq!(&reply.groups[0].last_delivered_id, &"0-0");
+
+    // call xadd on k99 just so we can read from it
+    // using consumer g99 and test xinfo_consumers
+    let _: RedisResult<String> = con.xadd("k99", "1000-0", &[("a", "b"), ("c", "d")]);
+    let _: RedisResult<String> = con.xadd("k99", "1000-1", &[("e", "f"), ("g", "h")]);
+
+    // passing options  w/ group triggers XREADGROUP
+    // using ID=">" means all undelivered ids
+    // otherwise, ID="0 | ms-num" means all pending already
+    // sent to this client
+    let reply: StreamReadReply = con
+        .xread_options(
+            &["k99"],
+            &[">"],
+            StreamReadOptions::default().group("g99", "c99"),
+        )
+        .unwrap();
+    assert_eq!(reply.keys[0].ids.len(), 2);
+
+    // read xinfo consumers again, should have 2 messages for the c99 consumer
+    let reply: StreamInfoConsumersReply = con.xinfo_consumers("k99", "g99").unwrap();
+    assert_eq!(reply.consumers[0].pending, 2);
+
+    // ack one of these messages
+    let result: RedisResult<i32> = con.xack("k99", "g99", &["1000-0"]);
+    assert_eq!(result, Ok(1));
+
+    // get pending messages already seen by this client
+    // we should only have one now..
+    let reply: StreamReadReply = con
+        .xread_options(
+            &["k99"],
+            &["0"],
+            StreamReadOptions::default().group("g99", "c99"),
+        )
+        .unwrap();
+    assert_eq!(reply.keys.len(), 1);
+
+    // we should also have one pending here...
+    let reply: StreamInfoConsumersReply = con.xinfo_consumers("k99", "g99").unwrap();
+    assert_eq!(reply.consumers[0].pending, 1);
+
+    // add more and read so we can test xpending
+    let _: RedisResult<String> = con.xadd("k99", "1001-0", &[("i", "j"), ("k", "l")]);
+    let _: RedisResult<String> = con.xadd("k99", "1001-1", &[("m", "n"), ("o", "p")]);
+    let _: StreamReadReply = con
+        .xread_options(
+            &["k99"],
+            &[">"],
+            StreamReadOptions::default().group("g99", "c99"),
+        )
+        .unwrap();
+
+    // call xpending here...
+    // this has a different reply from what the count variations return
+    let reply: StreamPendingReply = con.xpending("k99", "g99").unwrap();
+    assert_eq!(reply.count, 3);
+    assert_eq!(reply.start_id, "1000-1");
+    assert_eq!(reply.end_id, "1001-1");
+    assert_eq!(reply.consumers.len(), 1);
+    assert_eq!(reply.consumers[0].name, "c99");
+
+    // both count variations have the same reply types
+    let reply: StreamPendingCountReply = con.xpending_count("k99", "g99", "-", "+", 10).unwrap();
+    assert_eq!(reply.ids.len(), 3);
+
+    let reply: StreamPendingCountReply = con
+        .xpending_consumer_count("k99", "g99", "-", "+", 10, "c99")
+        .unwrap();
+    assert_eq!(reply.ids.len(), 3);
+}
+
+#[test]
+fn test_xclaim() {
+    // Tests the following commands....
+    // xclaim
+    // xclaim_options
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    // xclaim test basic idea:
+    // 1. we need to test adding messages to a group
+    // 2. then xreadgroup needs to define a consumer and read pending
+    //    messages without acking them
+    // 3. then we need to sleep 5ms and call xpending
+    // 4. from here we should be able to claim message
+    //    past the idle time and read them from a different consumer
+
+    // create the group
+    let result: RedisResult<String> = con.xgroup_create_mkstream("k1", "g1", "$");
+    assert_eq!(result.is_ok(), true);
+
+    // add some keys
+    xadd_keyrange(&mut con, "k1", 0, 10);
+
+    // read the pending items for this key & group
+    let reply: StreamReadReply = con
+        .xread_options(
+            &["k1"],
+            &[">"],
+            StreamReadOptions::default().group("g1", "c1"),
+        )
+        .unwrap();
+    // verify we have 10 ids
+    assert_eq!(reply.keys[0].ids.len(), 10);
+
+    // save this StreamId for later
+    let claim = &reply.keys[0].ids[0];
+    let _claim_1 = &reply.keys[0].ids[1];
+    let claim_justids = &reply.keys[0].just_ids();
+
+    // sleep for 5ms
+    sleep(Duration::from_millis(5));
+
+    // grab this id if > 4ms
+    let reply: StreamClaimReply = con
+        .xclaim("k1", "g1", "c2", 4, &[claim.id.clone()])
+        .unwrap();
+    assert_eq!(reply.ids.len(), 1);
+    assert_eq!(reply.ids[0].id, claim.id);
+
+    // grab all pending ids for this key...
+    // we should 9 in c1 and 1 in c2
+    let reply: StreamPendingReply = con.xpending("k1", "g1").unwrap();
+    assert_eq!(reply.consumers[0].name, "c1");
+    assert_eq!(reply.consumers[0].pending, 9);
+    assert_eq!(reply.consumers[1].name, "c2");
+    assert_eq!(reply.consumers[1].pending, 1);
+
+    // sleep for 5ms
+    sleep(Duration::from_millis(5));
+
+    // lets test some of the xclaim_options
+    // call force on the same claim.id
+    let _: StreamClaimReply = con
+        .xclaim_options(
+            "k1",
+            "g1",
+            "c3",
+            4,
+            &[claim.id.clone()],
+            StreamClaimOptions::default().with_force(),
+        )
+        .unwrap();
+
+    let reply: StreamPendingReply = con.xpending("k1", "g1").unwrap();
+    // we should have 9 w/ c1 and 1 w/ c3 now
+    assert_eq!(reply.consumers[1].name, "c3");
+    assert_eq!(reply.consumers[1].pending, 1);
+
+    // sleep for 5ms
+    sleep(Duration::from_millis(5));
+
+    // claim and only return JUSTID
+    let claimed: Vec<String> = con
+        .xclaim_options(
+            "k1",
+            "g1",
+            "c5",
+            4,
+            &claim_justids,
+            StreamClaimOptions::default().with_force().with_justid(),
+        )
+        .unwrap();
+    // we just claimed the origin 10 ids
+    // and only returned the ids
+    assert_eq!(claimed.len(), 10);
+}
+
+#[test]
+fn test_xdel() {
+    // Tests the following commands....
+    // xdel
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    // add some keys
+    xadd(&mut con);
+
+    // delete the first stream item for this key
+    let result: RedisResult<i32> = con.xdel("k1", &["1000-0"]);
+    // returns the number of items deleted
+    assert_eq!(result, Ok(1));
+
+    let result: RedisResult<i32> = con.xdel("k2", &["2000-0", "2000-1", "2000-2"]);
+    // should equal 2 since the last id doesn't exist
+    assert_eq!(result, Ok(2));
+}
+
+#[test]
+fn test_xtrim() {
+    // Tests the following commands....
+    // xtrim
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    // add some keys
+    xadd_keyrange(&mut con, "k1", 0, 100);
+
+    // trim key to 50
+    // returns the number of items remaining in the stream
+    let result: RedisResult<i32> = con.xtrim("k1", StreamMaxlen::Equals(50));
+    assert_eq!(result, Ok(50));
+    // we should end up with 40 after this call
+    let result: RedisResult<i32> = con.xtrim("k1", StreamMaxlen::Equals(10));
+    assert_eq!(result, Ok(40));
+}
+
+#[test]
+fn test_xgroup() {
+    // Tests the following commands....
+    // xgroup_create_mkstream
+    // xgroup_destroy
+    // xgroup_delconsumer
+
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    // test xgroup create w/ mkstream @ 0
+    let result: RedisResult<String> = con.xgroup_create_mkstream("k1", "g1", "0");
+    assert_eq!(result.is_ok(), true);
+
+    // destroy this new stream group
+    let result: RedisResult<i32> = con.xgroup_destroy("k1", "g1");
+    assert_eq!(result, Ok(1));
+
+    // add some keys
+    xadd(&mut con);
+
+    // create the group again using an existing stream
+    let result: RedisResult<String> = con.xgroup_create("k1", "g1", "0");
+    assert_eq!(result.is_ok(), true);
+
+    // read from the group so we can register the consumer
+    let reply: StreamReadReply = con
+        .xread_options(
+            &["k1"],
+            &[">"],
+            StreamReadOptions::default().group("g1", "c1"),
+        )
+        .unwrap();
+    assert_eq!(reply.keys[0].ids.len(), 2);
+
+    let result: RedisResult<i32> = con.xgroup_delconsumer("k1", "g1", "c1");
+    // returns the number of pending message this client had open
+    assert_eq!(result, Ok(2));
+
+    let result: RedisResult<i32> = con.xgroup_destroy("k1", "g1");
+    assert_eq!(result, Ok(1));
+}
+
+#[test]
+fn test_xrange() {
+    // Tests the following commands....
+    // xrange (-/+ variations)
+    // xrange_all
+    // xrange_count
+
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    xadd(&mut con);
+
+    // xrange replies
+    let reply: StreamRangeReply = con.xrange_all("k1").unwrap();
+    assert_eq!(reply.ids.len(), 2);
+
+    let reply: StreamRangeReply = con.xrange("k1", "1000-1", "+").unwrap();
+    assert_eq!(reply.ids.len(), 1);
+
+    let reply: StreamRangeReply = con.xrange("k1", "-", "1000-0").unwrap();
+    assert_eq!(reply.ids.len(), 1);
+
+    let reply: StreamRangeReply = con.xrange_count("k1", "-", "+", 1).unwrap();
+    assert_eq!(reply.ids.len(), 1);
+}
+
+#[test]
+fn test_xrevrange() {
+    // Tests the following commands....
+    // xrevrange (+/- variations)
+    // xrevrange_all
+    // xrevrange_count
+
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    xadd(&mut con);
+
+    // xrange replies
+    let reply: StreamRangeReply = con.xrevrange_all("k1").unwrap();
+    assert_eq!(reply.ids.len(), 2);
+
+    let reply: StreamRangeReply = con.xrevrange("k1", "1000-1", "-").unwrap();
+    assert_eq!(reply.ids.len(), 2);
+
+    let reply: StreamRangeReply = con.xrevrange("k1", "+", "1000-1").unwrap();
+    assert_eq!(reply.ids.len(), 1);
+
+    let reply: StreamRangeReply = con.xrevrange_count("k1", "+", "-", 1).unwrap();
+    assert_eq!(reply.ids.len(), 1);
+}


### PR DESCRIPTION
This PR adds the base set of commands to support Redis Streams using `redis-rs`. All this functionality is exposed through a new trait, `StreamCommands`. I've added a bunch of new structs to make working with Stream responses and passing optional arguments more user friendly.

To facilitate testing, we copied `tests/support/mod.rs` directly from the `redis-rs` crate. No need to deviate how things are done upstream for now.

Also, it's a bad idea to expose all publicly accessible `redis-rs` code here. I'm going to remove this. So the main use-case is using `redis-rs` first and only using `StreamCommands` & the various reply types from this library as an add-on.

For now, this PR has one a dependency upstream in the `redis-rs` crate. See the TODO list.

TODO:

- [ ] Mege this PR which makes RedisWrite publicly available.
- [ ] Update Cargo.toml w/ new redis dependency.
- [ ] Add CI build and release process.
- [ ] Add README.md.