### PR TITLE
Add enum case for StreamPendingResult and corresponding tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub use types::{
     StreamKey,
     StreamMaxlen,
     StreamPendingCountReply,
+    StreamPendingData,
     StreamPendingReply,
     StreamRangeReply,
     StreamReadOptions,


### PR DESCRIPTION
`StreamPendingResult` breaks if there are no items in the PEL as the `start_id`, `end_id` etc. are `nil` so cannot be coerced to a `String`.

Example:

```
> XPENDING some_key some_group
1) (integer) 0
2) (nil)
3) (nil)
4) (nil)
```

This fix creates an enum for the two different cases (when the PEL is empty, vs. when it is not), as well as adding tests.

Open to changes or comments regarding the naming, or whether it should be an enum or not. Conceptually I feel this is neater than using optionals or some token value for the nil.

(Also apologies if this doesn't abide by style guidelines - I'm fairly new to contributing to Rust projects so I'm not super familiar with docs etc. yet)