### PR TITLE
Minor fixup for 2018 edition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //! From here, just unlock the streaming commands prior to instantiating client connections.
 //!
 //! ```no_run
-//! extern crate redis_streams;
 //! use redis_streams::{client_open,Connection,StreamCommands};
 //! let client = client_open("redis://127.0.0.1/0").unwrap();
 //! let mut con = client.get_connection().unwrap();
@@ -24,27 +23,24 @@
 //! To pick up all `redis-rs` Commands, just use the `Commands` trait.
 //!
 //! ```no_run
-//! extern crate redis_streams;
 //! use redis_streams::{Commands};
 //! ```
 //!
 #![deny(non_camel_case_types)]
 
 #[doc(hidden)]
-pub extern crate redis;
-
 pub use redis::{Commands, Connection, RedisResult};
 
-pub use commands::StreamCommands;
+pub use crate::commands::StreamCommands;
 
-pub use types::{
+pub use crate::types::{
     // stream types
     StreamClaimOptions,
     StreamClaimReply,
     StreamId,
     StreamInfoConsumer,
-    StreamInfoGroup,
     StreamInfoConsumersReply,
+    StreamInfoGroup,
     StreamInfoGroupsReply,
     StreamInfoStreamReply,
     StreamKey,

--- a/tests/test_streams.rs
+++ b/tests/test_streams.rs
@@ -14,7 +14,7 @@ use std::str;
 use std::thread::sleep;
 use std::time::Duration;
 
-use support::*;
+use crate::support::*;
 
 mod support;
 


### PR DESCRIPTION
Results of running `cargo fix --edition`, and then stripping out unnecessary `extern crate` defns.